### PR TITLE
Update detekt to 2.0.0-alpha.5

### DIFF
--- a/common-test/build.gradle.kts
+++ b/common-test/build.gradle.kts
@@ -5,7 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(libs.detektTest)
+  // TODO remove when https://github.com/detekt/detekt/pull/9439 is released
+  implementation(libs.detektApi)
+  implementation(libs.detektTest) {
+    // TODO remove when https://github.com/detekt/detekt/pull/9439 is released
+    exclude(group = "dev.detekt", module = "detekt-api")
+  }
   implementation(libs.detektTestAssertj)
   implementation(libs.test.assertj)
 }

--- a/formatting/build.gradle.kts
+++ b/formatting/build.gradle.kts
@@ -9,7 +9,10 @@ dependencies {
   implementation(libs.detektApi)
 
   testImplementation(projects.commonTest)
-  testImplementation(libs.detektTest)
+  testImplementation(libs.detektTest) {
+    // TODO remove when https://github.com/detekt/detekt/pull/9439 is released
+    exclude(group = "dev.detekt", module = "detekt-api")
+  }
   testImplementation(libs.detektTestAssertj)
   testImplementation(libs.test.assertj)
   testImplementation(libs.test.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-detekt = "2.0.0-alpha.3"
+detekt = "2.0.0-alpha.5"
 
 dokka = "2.2.0"
 

--- a/style/build.gradle.kts
+++ b/style/build.gradle.kts
@@ -9,7 +9,10 @@ dependencies {
   implementation(libs.detektApi)
 
   testImplementation(projects.commonTest)
-  testImplementation(libs.detektTest)
+  testImplementation(libs.detektTest) {
+    // TODO remove when https://github.com/detekt/detekt/pull/9439 is released
+    exclude(group = "dev.detekt", module = "detekt-api")
+  }
   testImplementation(libs.detektTestAssertj)
   testImplementation(libs.test.assertj)
   testImplementation(libs.test.junit)


### PR DESCRIPTION
Bumps detekt from `2.0.0-alpha.3` to `2.0.0-alpha.5`.

## The dependency break

`detekt-test` 2.0.0-alpha.5's `runtimeElements` variant requests `dev.detekt:detekt-api` with the capability `dev.detekt:detekt-api-test-fixtures`, which isn't published. Any runtime classpath containing `detekt-test` therefore fails to resolve:

```
+--- dev.detekt:detekt-test:2.0.0-alpha.5
|    +--- dev.detekt:detekt-api:2.0.0-alpha.5 FAILED
```

Upstream fix is detekt/detekt#9439 (merged, targeting 2.0.0), so this is a temporary workaround — same approach as TWiStErRob/net.twisterrob.detekt#222.

## Changes

- Exclude `dev.detekt:detekt-api` from `detektTest` and depend on `detekt-api` directly.
- `style` and `formatting` already declare `implementation(libs.detektApi)`, which `testImplementation` extends, so the real `detekt-api` stays on the test classpath.
- `common-test` was picking up `detekt-api` transitively from `detekt-test`, so it now declares `implementation(libs.detektApi)` explicitly.

Each exclude is tagged with a `// TODO` pointing at detekt/detekt#9439 so they can be dropped on the next bump.

## Testing

`./gradlew build` passes — compilation, detekt, and the `style` / `formatting` test suites. Verified the excludes are load-bearing: removing one reproduces the `FAILED` resolution above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
